### PR TITLE
Add a stringify stream

### DIFF
--- a/lib/json-stream.js
+++ b/lib/json-stream.js
@@ -1,20 +1,25 @@
 var util = require('util'),
     TransformStream = require('stream').Transform;
 
-module.exports = function () {
-  return new JSONStream();
-};
+module.exports = ParseStream
 
-var JSONStream = module.exports.JSONStream = function () {
+
+module.exports.JSONStream = ParseStream
+module.exports.parse = ParseStream
+module.exports.stringify = StringifyStream
+
+function ParseStream() {
+  if(!(this instanceof ParseStream)) return new ParseStream
+
   this._buffer = '';
 
   TransformStream.call(this, {
     objectMode: true // wtf node, why do I even need it?!
   });
 };
-util.inherits(JSONStream, TransformStream);
+util.inherits(ParseStream, TransformStream);
 
-JSONStream.prototype._transform = function (data, encoding, callback) {
+ParseStream.prototype._transform = function (data, encoding, callback) {
   data = this._buffer + data.toString('utf8');
 
   var lines = data.split('\n'),
@@ -34,3 +39,19 @@ JSONStream.prototype._transform = function (data, encoding, callback) {
 
   callback();
 };
+
+
+function StringifyStream() {
+  if(!(this instanceof StringifyStream)) return new StringifyStream
+
+  TransformStream.call(this, {
+    objectMode: true
+  });
+};
+util.inherits(StringifyStream, TransformStream);
+
+StringifyStream.prototype._transform = function (object, encoding, callback) {
+  this.push(new Buffer(JSON.stringify(object)+'\n', 'utf8'))
+  callback();
+};
+

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "author": "Maciej Małecki <me@mmalecki.com>",
   "main": "./lib/json-stream",
   "scripts": {
-    "test": "node test/pipe-test.js && node test/json-stream-test.js"
+    "test": "node test/pipe-test.js && node test/json-parse-test.js && node test/json-stringify-test.js"
   }
 }

--- a/test/json-parse-test.js
+++ b/test/json-parse-test.js
@@ -29,26 +29,32 @@ function expect(stream, events) {
   });
 }
 
-var stream = JSONStream();
+// JSONStream.parse
+
+var stream = JSONStream.parse();
 expect(stream, [ { a: 42 } ]);
 write(stream, '{"a": 42}\n');
 
-stream = JSONStream();
+stream = new JSONStream.parse();
+expect(stream, [ { a: 42 } ]);
+write(stream, '{"a": 42}\n');
+
+stream = JSONStream.parse();
 expect(stream, [ { a: 42 } ]);
 write(stream, '{"a":', '42}\n');
 
-stream = JSONStream();
+stream = JSONStream.parse();
 expect(stream, [ { a: 42, b: 1337 } ]);
 write(stream, '{"a":', '42', ',"b": 1337', '}\n');
 
-stream = JSONStream();
+stream = JSONStream.parse();
 expect(stream, [ { a: 42, b: 1337 }, { hello: 'world' } ]);
 write(stream, '{"a":', '42', ',"b": 1337', '}\n{"hel', 'lo": "wor', 'ld"}\n');
 
-stream = JSONStream();
+stream = JSONStream.parse();
 expect(stream, [ { a: 42 }, { hello: 'world' } ]);
 write(stream, '{"a":', '42}\n{ blah blah blah }\n{"hel', 'lo": "wor', 'ld"}\n');
 
-stream = JSONStream();
+stream = JSONStream.parse();
 expect(stream, [ { a: 42 }, { hello: 'world' } ]);
 write(stream, '{"a":', '42}\n{ blah blah', 'blah }\n{"hel', 'lo": "wor', 'ld"}\n');

--- a/test/json-stringify-test.js
+++ b/test/json-stringify-test.js
@@ -1,0 +1,44 @@
+var assert = require('assert'),
+    JSONStream = require('../');
+
+function write(stream, writes) {
+  writes.forEach(function (write) {
+    stream.write(write);
+  });
+  stream.end();
+}
+
+function expect(stream, string) {
+  var output = '', endCalled = false;
+  stream.on('readable', function () {
+    var chunk = stream.read();
+    if (chunk) {
+      output += chunk.toString();
+    }
+  });
+  stream.on('end', function () {
+    endCalled = true;
+  });
+  process.on('exit', function () {
+    assert.equal(output, string);
+    assert(endCalled);
+  });
+}
+
+// JSONStream.stringify
+
+var stream = JSONStream.stringify();
+expect(stream, '{"a":42}\n');
+write(stream, [{ a: 42 }]);
+
+var stream = new JSONStream.stringify();
+expect(stream, '{"a":42}\n');
+write(stream, [{ a: 42 }]);
+
+stream = JSONStream.stringify();
+expect(stream, '{"a":42,"b":1337}\n');
+write(stream, [{ a: 42, b: 1337 }]);
+
+stream = JSONStream.stringify();
+expect(stream, '{"a":42,"b":1337}\n{"hello":"world"}\n');
+write(stream, [ { a: 42, b: 1337 }, { hello: 'world' } ]);


### PR DESCRIPTION
I love the simplicity of your module, but I'd love to have a matching stringify stream.

``` js
var JSONstream = require('json-stream')

// ...

process.stdin.pipe(JSONstream.parse()).pipe(dbstream)
dbstream.pipe(JSON.stringify()).pipe(process.stdout)
```

Also it's still fully backwards compatible.
